### PR TITLE
Update(readme): uniCLoud>uniCloud

### DIFF
--- a/zh-cn/cli/README.md
+++ b/zh-cn/cli/README.md
@@ -50,5 +50,5 @@ cli app quit
 |文件操作，打开文件并跳转指定行列				|[详情](/cli/file)					|
 |项目操作，导入、关闭项目				|[详情](/cli/project)					|
 |app打包												|[详情](/cli/pack)						|
-|uniCLoud操作，比如云函数上传等	|[详情](/cli/uniCloud)				|
+|uniCloud操作，比如云函数上传等	|[详情](/cli/uniCloud)				|
 |uniCloud 前端网页托管					|[详情](/cli/uniCloud-hosting)|


### PR DESCRIPTION
这里的uniCLoud L大写了，相对感觉uniCloud这样更和谐一点