### PR TITLE
fix: 修复when表达式（简/繁）锚点错误

### DIFF
--- a/zh-cn/ExtensionDocs/ContributionPoints/README.md
+++ b/zh-cn/ExtensionDocs/ContributionPoints/README.md
@@ -247,7 +247,7 @@ menus节点下配置的对象内的key指的是要注册到哪个**`弹出菜单
 |title			|String		|否			|菜单项的名称，如果没有配置，将采用`命令`的title											|
 |[group](#group)|String		|是			|菜单项要注册的位置,查看目前支持的[group列表](#group)。注意该属性必须写，不写视为无效菜单扩展	|
 |[when](#when%e8%a1%a8%e8%be%be%e5%bc%8f)	|String		|否			|控制菜单项是否显示的逻辑表达式,[表达式说明](#when%e8%a1%a8%e8%be%be%e5%bc%8f)											|
-|checked	    |String		|否			|`从HBuilderX 2.7.6及以上版本开始支持` <br/>控制菜单项是否处于checked的逻辑表达式,表达式语法和[when](#when)表达式一致										|
+|checked	    |String		|否			|`从HBuilderX 2.7.6及以上版本开始支持` <br/>控制菜单项是否处于checked的逻辑表达式,表达式语法和[when](#when%e8%a1%a8%e8%be%be%e5%bc%8f)表达式一致										|
 
 > 当属性title和command都为空时，将被识别为分割线。
 

--- a/zh-cn/ExtensionDocs/ContributionPoints/README.md
+++ b/zh-cn/ExtensionDocs/ContributionPoints/README.md
@@ -246,7 +246,7 @@ menus节点下配置的对象内的key指的是要注册到哪个**`弹出菜单
 |command		|String		|否			|菜单项关联的`命令`Id																		|
 |title			|String		|否			|菜单项的名称，如果没有配置，将采用`命令`的title											|
 |[group](#group)|String		|是			|菜单项要注册的位置,查看目前支持的[group列表](#group)。注意该属性必须写，不写视为无效菜单扩展	|
-|[when](#when)	|String		|否			|控制菜单项是否显示的逻辑表达式,[表达式说明](#when)											|
+|[when](#when%e8%a1%a8%e8%be%be%e5%bc%8f)	|String		|否			|控制菜单项是否显示的逻辑表达式,[表达式说明](#when%e8%a1%a8%e8%be%be%e5%bc%8f)											|
 |checked	    |String		|否			|`从HBuilderX 2.7.6及以上版本开始支持` <br/>控制菜单项是否处于checked的逻辑表达式,表达式语法和[when](#when)表达式一致										|
 
 > 当属性title和command都为空时，将被识别为分割线。

--- a/zh-hant/ExtensionDocs/ContributionPoints/README.md
+++ b/zh-hant/ExtensionDocs/ContributionPoints/README.md
@@ -246,7 +246,7 @@ menus節點下配置的對象內的key指的是要註冊到哪個**`彈出菜單
 |command		|String		|否			|菜單項關聯的`命令`Id																		|
 |title			|String		|否			|菜單項的名稱，如果沒有配置，將采用`命令`的title											|
 |[group](#group)|String		|是			|菜單項要註冊的位置,查看目前支持的[group列表](#group)。註意該屬性必須寫，不寫視為無效菜單擴展	|
-|[when](#when)	|String		|否			|控制菜單項是否顯示的邏輯表達式,[表達式說明](#when)											|
+|[when](#when%e8%a1%a8%e9%81%94%e5%bc%8f)	|String		|否			|控制菜單項是否顯示的邏輯表達式,[表達式說明](#when%e8%a1%a8%e9%81%94%e5%bc%8f)											|
 |checked	    |String		|否			|`從HBuilderX 2.7.6及以上版本開始支持` <br/>控制菜單項是否處於checked的邏輯表達式,表達式語法和[when](#when)表達式壹致										|
 
 > 當屬性title和command都為空時，將被識別為分割線。

--- a/zh-hant/ExtensionDocs/ContributionPoints/README.md
+++ b/zh-hant/ExtensionDocs/ContributionPoints/README.md
@@ -247,7 +247,7 @@ menus節點下配置的對象內的key指的是要註冊到哪個**`彈出菜單
 |title			|String		|否			|菜單項的名稱，如果沒有配置，將采用`命令`的title											|
 |[group](#group)|String		|是			|菜單項要註冊的位置,查看目前支持的[group列表](#group)。註意該屬性必須寫，不寫視為無效菜單擴展	|
 |[when](#when%e8%a1%a8%e9%81%94%e5%bc%8f)	|String		|否			|控制菜單項是否顯示的邏輯表達式,[表達式說明](#when%e8%a1%a8%e9%81%94%e5%bc%8f)											|
-|checked	    |String		|否			|`從HBuilderX 2.7.6及以上版本開始支持` <br/>控制菜單項是否處於checked的邏輯表達式,表達式語法和[when](#when)表達式壹致										|
+|checked	    |String		|否			|`從HBuilderX 2.7.6及以上版本開始支持` <br/>控制菜單項是否處於checked的邏輯表達式,表達式語法和[when](#when%e8%a1%a8%e9%81%94%e5%bc%8f)表達式壹致										|
 
 > 當屬性title和command都為空時，將被識別為分割線。
 


### PR DESCRIPTION
详见[menus属性列表](https://hx.dcloud.net.cn/ExtensionDocs/ContributionPoints/README?id=menus%e5%b1%9e%e6%80%a7%e5%88%97%e8%a1%a8)页面when的链接指向。